### PR TITLE
Replace py-hubstorage with py-scrapinghub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Scrapy>=1.0.3
-hubstorage>=0.21.0
+scrapinghub>=1.9.0

--- a/scrapy_pagestorage.py
+++ b/scrapy_pagestorage.py
@@ -4,8 +4,8 @@ Middleware for implementing visited pages storage using hubstorage
 import os
 from cgi import parse_qsl
 
-from hubstorage import ValueTooLarge
-from hubstorage.utils import urlpathjoin
+from scrapinghub.hubstorage import ValueTooLarge
+from scrapinghub.hubstorage.utils import urlpathjoin
 from scrapy.exceptions import NotConfigured, IgnoreRequest
 from scrapy.utils.request import request_fingerprint
 from scrapy.http import TextResponse

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     install_requires=[
         'Scrapy>=1.0.3',
-        'hubstorage>=0.21',
+        'scrapinghub>=1.9.0',
         'scrapinghub-entrypoint-scrapy>=0.4',
     ],
     dependency_links=[


### PR DESCRIPTION
As python-hubstorage is deprecated, let's replace it with python-scrapinghub.

Review, please.