### PR TITLE
#2 Split header using `b';'` and decode as `ISO-8859-1`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 2.7
+python: 3.6
 branches:
   only:
   - master
@@ -7,6 +7,9 @@ branches:
   - /^v\d\.\d+\.\d+(rc\d+|dev\d+)?$/
 env:
 - TOXENV=py27
+- TOXENV=py33
+- TOXENV=py34
+- TOXENV=py36
 install:
 - pip install -U tox twine wheel codecov
 script: tox

--- a/scrapy_pagestorage.py
+++ b/scrapy_pagestorage.py
@@ -106,7 +106,7 @@ class PageStorageMiddleware:
 
     def _set_cookies(self, payload, response):
         cookies = []
-        for cookie in [x.split(';', 1)[0]
+        for cookie in [x.split(b';', 1)[0].decode('ISO-8859-1')
                        for x in response.headers.getlist('Set-Cookie')]:
             if cookie not in self.cookies_seen:
                 self.cookies_seen.add(cookie)

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.6',
     ],
     install_requires=[
         'Scrapy>=1.0.3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # tox.ini
 [tox]
-envlist = py27
+envlist = py27, py33
 
 [testenv]
 deps =


### PR DESCRIPTION
In Py3 scrapy returns headers as bytes which can't be split by a Py3 unicode character (str in Py3). This is solved by using a Py3 bytes character to split the header.
The other issue this solves is that JSON doesn't know how to convert the bytes to unicode so the headers need to be decoded as `ISO-8859-1`. Although `ASCII` should work there are some older sites that used the `ISO-8859-1` encoding for headers so using this should provide the most compatability.