### PR TITLE
Support universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
The current wheel file on PyPI seems to be a Py3-only wheel, but since the library supports Python 2 and 3, a universal wheel could support both versions.