### PR TITLE
Decode request body before writing to avoid type error

### DIFF
--- a/scrapy_pagestorage.py
+++ b/scrapy_pagestorage.py
@@ -87,7 +87,7 @@ class PageStorageMiddleware:
             self._set_cookies(payload, response)
 
             if response.request.method == 'POST':
-                payload["postdata"] = dict(parse_qsl(response.request.body))
+                payload["postdata"] = dict(parse_qsl(response.request.body.decode()))
 
             payload["body"] = response.body_as_unicode()
             if self.trim_html:


### PR DESCRIPTION
In Scrapy FormRequest method, `self._set_body(querystr)` method converts body into byte and this raises error when trying to store this using page storage middle-ware
```def _set_body(self, body):
    if body is None:
        self._body = b''
    else:
        self._body = to_bytes(body, self.encoding)```