### PR TITLE
Add Scrapy 1.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,15 @@ branches:
   - master
   - /^\d\.\d+$/
   - /^v\d\.\d+\.\d+(rc\d+|dev\d+)?$/
-python:
-  - 3.6
-
+matrix:
+    include:
+        - python: 2.7
+          env: TOXENV=py27
+        - python: 3.6
+          env: TOXENV=py36
+        - python: 3.7
+          env: TOXENV=py37
+          dist: xenial
 install:
 - pip install -U tox twine wheel codecov
 script: tox

--- a/scrapy_pagestorage.py
+++ b/scrapy_pagestorage.py
@@ -10,7 +10,7 @@ from scrapinghub.hubstorage.utils import urlpathjoin
 from scrapy.exceptions import NotConfigured, IgnoreRequest
 from scrapy.utils.request import request_fingerprint
 from scrapy.http import TextResponse
-from scrapy import log, signals
+from scrapy import signals
 from scrapy.item import DictItem, Field
 
 logger = logging.getLogger(__name__)
@@ -94,15 +94,15 @@ class PageStorageMiddleware:
                 payload['body'] = payload['body'].strip(' \r\n\0')
 
             if len(payload['body']) > self._writer.maxitemsize:
-                spider.log("Page not saved, body too large: <%s>" %
-                           response.url, level=log.WARNING)
+                spider.logger.warning("Page not saved, body too large: <%s>" %
+                                      response.url)
                 return
 
             try:
                 self._writer.write(payload)
             except ValueTooLarge as exc:
-                spider.log("Page not saved, %s: <%s>" %
-                           (exc, response.url), level=log.WARNING)
+                spider.logger.warning("Page not saved, %s: <%s>" %
+                                      (exc, response.url))
 
     def process_spider_output(self, response, result, spider):
         fp = request_fingerprint(response.request)

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,6 @@
 # tox.ini
 [tox]
-envlist = py27, py36, py37
-
-[tox:travis]
-2.7 = py27
-3.6 = py36
-3.7 = py37
+envlist = py27
 
 [testenv]
 deps =
@@ -15,3 +10,9 @@ deps =
 install_command=pip install --process-dependency-links {opts} {packages}
 commands =
     py.test
+
+[testenv:py36]
+basepython = python3.6
+
+[testenv:py37]
+basepython = python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 # tox.ini
 [tox]
-envlist = py27, py34, py36
+envlist = py27, py36, py37
 
 [tox:travis]
 2.7 = py27
-3.4 = py34
 3.6 = py36
+3.7 = py37
 
 [testenv]
 deps =


### PR DESCRIPTION
Recent Scrapy 1.7 [dropped](https://docs.scrapy.org/en/latest/news.html#deprecation-removals) support for deprecated `scrapy.log`.